### PR TITLE
Configure Docker ENTRYPOINT and default arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src/ /app/src/
 
-CMD ["python", "src/py_connect_test/main.py"]
+ENTRYPOINT ["python", "src/py_connect_test/main.py"]
+CMD ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ omit = [
 
 [tool.poetry]
 name = "py_connect_test"
-version = "2.2.0"
+version = "2.2.1"
 description = "A simple Python package for testing connectivity."
 
 packages = [


### PR DESCRIPTION
Sets the main application script as the container's `ENTRYPOINT` to ensure it is always executed. Updates `CMD` to provide `test` as the default argument to the `ENTRYPOINT`, allowing users to override it when running the container.