### PR TITLE
Introduce Alertmanager payload template and refine default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 # py-connect-test
 
-A simple Python package to test HTTP connectivity to URLs and retrieve status codes. Built with Typer CLI framework and httpx.
+A simple Python package to test basic HTTP connectivity to URLs. Built with Typer CLI framework and httpx.
+Can be used for monitoring, debugging, or as a health check tool in various environments such as ntfy, healchecks.io, or custom monitoring solutions.
 
 ## Prerequisites
 
@@ -31,7 +32,7 @@ poetry install
 
 ### Basic Usage
 
-Test connectivity to the default URL (https://ifconfig.me):
+Test connectivity to a URL specified in the `PY_CONNECT_TEST_URL` environment variable:
 
 ```bash
 py-connect-test test
@@ -79,7 +80,7 @@ docker build -t py-connect-test:latest .
 
 ```bash
 docker run -d \
-  -e HTTP_URL=https://example.com \
+  -e PY_CONNECT_TEST_URL=https://example.com \
   -e WEBHOOK_URL=http://prometheus.local \
   ghcr.io/tech1ndex/py-connect-test:latest
 ```
@@ -102,17 +103,16 @@ Available architectures:
 Pull specific architecture:
 
 ```bash
-docker pull ghcr.io/tech1ndex/py-connect-test:latest-amd64
-docker pull ghcr.io/tech1ndex/py-connect-test:latest-arm64
+docker pull ghcr.io/tech1ndex/py-connect-test:latest
 ```
 
 ## Environment Variables
 
-| Variable              | Description | Default | Required |
-|-----------------------|-------------|---------|----------|
-| `PY_CONNECT_TEST_URL` | URL to test connectivity to | `https://ifconfig.me` | No |
-| `WEBHOOK_URL`         | Webhook URL for alerts | `http://prometheus.local` | No |
-| `PAYLOAD_FILE_PATH`   | Path to JSON payload file for webhooks | `/tmp/payload.json` | No |
+| Variable              | Description | Default                   | Required |
+|-----------------------|-------------|---------------------------|----------|
+| `PY_CONNECT_TEST_URL` | URL to test connectivity to | `https://ntfy.me`         | Yes      |
+| `WEBHOOK_URL`         | Webhook URL for alerts | `http://prometheus.local` | No       |
+| `PAYLOAD_FILE_PATH`   | Path to JSON payload file for webhooks | `/app/src/py_connect_test/templates/alertmanager-payload.json` | No       |
 
 
 ## Project Structure

--- a/src/py_connect_test/settings.py
+++ b/src/py_connect_test/settings.py
@@ -4,9 +4,10 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class HttpSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="PY_CONNECT_TEST_")
 
-    url: str = "https://ifconfig.me"
+    url: str = "https://ntfy.me"
 
 
 class AlertSettings(BaseSettings):
+
     webhook_url: str = "http://prometheus.local"
-    payload_file_path: str = "payload.json"
+    payload_file_path: str = "/app/src/py_connect_test/templates/alertmanager-payload.json"

--- a/src/py_connect_test/templates/alertmanager-payload.json
+++ b/src/py_connect_test/templates/alertmanager-payload.json
@@ -1,0 +1,38 @@
+{
+  "receiver": "webhook",
+  "status": "firing",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "ServiceDown",
+        "severity": "critical",
+        "service": "my-service",
+        "instance": "my-service:8080",
+        "job": "py-connect-test",
+        "environment": "production"
+      },
+      "annotations": {
+        "summary": "Service my-service is unreachable",
+        "description": "Connectivity check to my-service:8080 failed. The service may be down or unreachable."
+      },
+      "startsAt": "2026-05-23T00:00:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "http://prometheus.local/graph"
+    }
+  ],
+  "groupLabels": {
+    "alertname": "ServiceDown"
+  },
+  "commonLabels": {
+    "alertname": "ServiceDown",
+    "severity": "critical",
+    "service": "my-service"
+  },
+  "commonAnnotations": {
+    "summary": "Service my-service is unreachable"
+  },
+  "externalURL": "http://alertmanager.local",
+  "version": "4",
+  "groupKey": "{}:{alertname=\"ServiceDown\"}"
+}


### PR DESCRIPTION
Adds a default Alertmanager-compatible JSON payload template to simplify integration with alerting systems. The default test URL is updated to `https://ntfy.me` to reflect a more common monitoring target, and `PY_CONNECT_TEST_URL` is now explicitly required.